### PR TITLE
Do not serialize commitment ZKP to save space

### DIFF
--- a/internal/cs.go
+++ b/internal/cs.go
@@ -723,10 +723,23 @@ type Body struct {
 }
 
 func (b Body) Bytes() []byte {
-	bodyBytes, err := asn1.Marshal(b)
+	bodyToSerialize := Body{}
+	for _, cmt := range b.Commitments {
+		bodyToSerialize.Commitments = append(bodyToSerialize.Commitments, committee.Commitment{
+			Data: cmt.Data,
+			From: cmt.From,
+		})
+	}
+
+	for _, reconShare := range b.ReconShares {
+		bodyToSerialize.ReconShares = append(bodyToSerialize.ReconShares, reconShare)
+	}
+
+	bodyBytes, err := asn1.Marshal(bodyToSerialize)
 	if err != nil {
 		panic(err)
 	}
+
 	return bodyBytes
 }
 


### PR DESCRIPTION
This reduces the size of the state by ~ 66%

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>