### PR TITLE
Use binary search to compute committee size and add UTs

### DIFF
--- a/internal/hg.go
+++ b/internal/hg.go
@@ -5,31 +5,43 @@ SPDX-License-Identifier: Apache-2.0
 
 package cs
 
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+)
 
 func CommitteeSize(totalNodeCount int64, failedTotalNodesPercentage int64, failureChance big.Rat) int {
 	if totalNodeCount < 4 {
 		return int(totalNodeCount)
 	}
-	byzantineRatio, _ := big.NewRat(failedTotalNodesPercentage, 100).Float64()
-	for committeeSize := int64(4); committeeSize <= totalNodeCount; committeeSize++ {
-		p := hyperGeomRangeSum(totalNodeCount, committeeSize, byzantineRatio)
-		if failureChance.Cmp(p) > 0 {
-			return int(committeeSize)
-		}
+
+	if failedTotalNodesPercentage == 33 {
+		return int(totalNodeCount)
 	}
 
-	return int(totalNodeCount)
+	failureChanceFloat, _ := failureChance.Float64()
+
+	byzantineRatio := float64(failedTotalNodesPercentage) / 100
+
+	return int(binarySearch(4, totalNodeCount, func(committeeSize int64) cmp {
+		p := 1 - hyperGeomRangeSum(totalNodeCount, committeeSize, byzantineRatio)
+		return failureChanceFloat > p
+	}))
 }
 
-func hyperGeomRangeSum(N, n int64, byzantine float64) *big.Rat {
-	third := n / 3
+func hyperGeomRangeSum(N, n int64, byzantine float64) float64 {
+	third := (n - 1) / 3
 	sum := big.NewRat(0, 1)
 	for t := int64(0); t <= third; t++ {
 		hg := hyperGeom(N, n, t, byzantine)
 		sum.Add(sum, hg)
 	}
-	return sum
+
+	floatSum, exact := sum.Float64()
+	if !exact && floatSum > 1 {
+		panic(fmt.Errorf("float sum is %f", floatSum))
+	}
+	return floatSum
 }
 
 func hyperGeom(total, committeeTotal, committeeByzantine int64, byzantineRatio float64) *big.Rat {
@@ -58,4 +70,24 @@ func bigToRat(n *big.Int) *big.Rat {
 
 func choose(n, k int64) *big.Int {
 	return big.NewInt(0).Binomial(n, k)
+}
+
+type cmp bool
+
+const (
+	bigger cmp = true
+	smaller
+)
+
+func binarySearch(low, high int64, pred func(n int64) cmp) int64 {
+	for low < high {
+		mid := (high + low) / 2
+		if pred(mid) {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+
+	return low
 }

--- a/internal/hg_test.go
+++ b/internal/hg_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cs
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitteeSize(t *testing.T) {
+	type args struct {
+		totalNodeCount             int64
+		failedTotalNodesPercentage int64
+		failureChance              big.Rat
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "4 nodes",
+			want: 4,
+			args: args{
+				failedTotalNodesPercentage: 33,
+				failureChance:              *big.NewRat(1, 100),
+				totalNodeCount:             4,
+			},
+		},
+		{
+			name: "11 nodes",
+			want: 4,
+			args: args{
+				failedTotalNodesPercentage: 1,
+				failureChance:              *big.NewRat(1, 100),
+				totalNodeCount:             11,
+			},
+		},
+		{
+			name: "1000 nodes 33% byzantine",
+			want: 1000,
+			args: args{
+				failedTotalNodesPercentage: 33,
+				failureChance:              *big.NewRat(1, 100),
+				totalNodeCount:             1000,
+			},
+		},
+		{
+			name: "1000 nodes 10% byzantine, slim failure chance",
+			want: 79,
+			args: args{
+				failedTotalNodesPercentage: 10,
+				failureChance:              *big.NewRat(1, 1000000000),
+				totalNodeCount:             1000,
+			},
+		},
+		{
+			name: "5000 nodes 20% byzantine, moderate failure chance",
+			want: 223,
+			args: args{
+				failedTotalNodesPercentage: 20,
+				failureChance:              *big.NewRat(1, 1000000),
+				totalNodeCount:             5000,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			committeeSize := CommitteeSize(tt.args.totalNodeCount, tt.args.failedTotalNodesPercentage, tt.args.failureChance)
+			if committeeSize != tt.want {
+				t.Errorf("CommitteeSize() = %v, want %v", committeeSize, tt.want)
+			}
+			byzantineRatio := float64(tt.args.failedTotalNodesPercentage) / 100
+			failureChance, _ := tt.args.failureChance.Float64()
+			p := 1 - hyperGeomRangeSum(tt.args.totalNodeCount, int64(committeeSize), byzantineRatio)
+			assert.LessOrEqual(t, p, failureChance)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>